### PR TITLE
Revert "Bump transmission-rpc from 3.4.0 to 4.1.0 in /flexget"

### DIFF
--- a/flexget/requirements.txt
+++ b/flexget/requirements.txt
@@ -1,2 +1,2 @@
 FlexGet==3.5.27
-transmission-rpc==4.1.0
+transmission-rpc==3.4.0


### PR DESCRIPTION
Reverts rickselby-servers/transmission#58

https://github.com/Flexget/Flexget/issues/3699